### PR TITLE
Remove obsolete permission update

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -176,10 +176,6 @@ class Config
             $this->filesystem
                 ->getDirectoryWrite(DirectoryList::MEDIA)
                 ->create($path);
-
-            $this->filesystem
-                ->getDirectoryWrite(DirectoryList::MEDIA)
-                ->changePermissions($path, 777);
         }
 
         return $path;


### PR DESCRIPTION
The permission update didn't function correctly. It would block directory access instead of opening it.

Default permission when using create($path); is 0777. So not updating it solved the issues 👍