### PR TITLE
Allow custom sidebar blocks

### DIFF
--- a/view/adminhtml/templates/post/edit/sidebar.phtml
+++ b/view/adminhtml/templates/post/edit/sidebar.phtml
@@ -9,11 +9,7 @@
 <input type="hidden" name="post[preview]" id="preview" value="">
 
 <div class="blog__post-sidebar">
-    <?= $this->getChildHtml('publish') ?>
-    <?= $this->getChildHtml('categories') ?>
-    <?= $this->getChildHtml('tags') ?>
-    <?= $this->getChildHtml('author') ?>
-    <?= $this->getChildHtml('image') ?>
+    <?= $this->getChildHtml() ?>
 </div>
 
 <script>


### PR DESCRIPTION
Using `$this->getChildHtml()` renders the same list. But will allow external modification of the block.