### PR TITLE
Create new post when needed, not before

### DIFF
--- a/Controller/Adminhtml/Post.php
+++ b/Controller/Adminhtml/Post.php
@@ -90,8 +90,10 @@ abstract class Post extends Action
     public function initModel()
     {
         $model = $this->postFactory->create();
-        if ($this->getRequest()->getParam('id')) {
-            $model->load($this->getRequest()->getParam('id'));
+        $id = $this->getRequest()->getParam('id');
+        
+        if ($id && ! is_array($id)) {
+            $model->load($id);
         }
 
         $this->registry->register('current_model', $model);

--- a/Controller/Adminhtml/Post/Edit.php
+++ b/Controller/Adminhtml/Post/Edit.php
@@ -18,7 +18,7 @@ class Edit extends Post
         $id = $this->getRequest()->getParam('id');
         $model = $this->initModel();
 
-        if ($id && !$model->getId()) {
+        if ($id && ! is_array($id) && !$model->getId()) {
             $this->messageManager->addError(__('This post no longer exists.'));
             return $this->resultRedirectFactory->create()->setPath('*/*/');
         }

--- a/Controller/Adminhtml/Post/Index.php
+++ b/Controller/Adminhtml/Post/Index.php
@@ -12,19 +12,13 @@ class Index extends Post
      */
     public function execute()
     {
-        $emptyPosts = $this->postFactory->create()->getCollection()
-            ->addAttributeToFilter('name', ['eq' => '']);
-
-        foreach ($emptyPosts as $post) {
-            $post->delete();
-        }
-
-
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
 
         $this->initPage($resultPage)
-            ->getConfig()->getTitle()->prepend(__('All Posts'));
+             ->getConfig()
+             ->getTitle()
+             ->prepend(__('All Posts'));
 
         return $resultPage;
     }

--- a/Controller/Adminhtml/Post/NewAction.php
+++ b/Controller/Adminhtml/Post/NewAction.php
@@ -11,10 +11,6 @@ class NewAction extends Post
      */
     public function execute()
     {
-        $post = $this->initModel()
-            ->setName('')
-            ->save();
-
-        return $this->resultRedirectFactory->create()->setPath('*/*/edit', ['id' => $post->getId()]);
+        return $this->resultRedirectFactory->create()->setPath('*/*/edit');
     }
 }


### PR DESCRIPTION
When clicking 'new post' a new post model would be initiated and saved with empty contents. This would create empty posts that are never removed. I fixed the usual behaviour, when clicking new post you go to the edit page. When clicking save the new post is saved to the DB.

The `is_array` check on the id is needed because the edit page has a related products grid which has an option to filter by id. The name of the post value is `id[from]` and `id[to]` which causes `->getParam('id')` to return an array taken from the post values.