### PR TITLE
Set saved file name based on the uploader result

### DIFF
--- a/Model/ResourceModel/Post.php
+++ b/Model/ResourceModel/Post.php
@@ -333,8 +333,12 @@ class Post extends AbstractEntity
             ->setAllowCreateFolders(true)
             ->setAllowRenameFiles(false)
             ->setFilesDispersion(false);
-        $uploader->save($this->config->getMediaPath(), $newFileName);
-
+        $result = $uploader->save($this->config->getMediaPath(), $newFileName);
+        
+        if (isset($result['file']) ) {
+            $newFileName = $result['file'];
+        }
+        
         $post->setFeaturedImage($newFileName);
 
         if ($newFileName != $oldFileName) {


### PR DESCRIPTION
Hello,

When we're uploading a file (an image specifically) that contains a space in the file name, Magento's `FileUploader` is replacing spaces with an `_`. 

The code that then saves the new file name against the blog post doesn't respect this change to the file name, so I have included a patch that sets the file name based on the result of the file uploader.