### PR TITLE
Added blog_page_render event

### DIFF
--- a/Controller/Post.php
+++ b/Controller/Post.php
@@ -2,10 +2,8 @@
 
 namespace Mirasvit\Blog\Controller;
 
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session;
 use Mirasvit\Blog\Model\PostFactory;
 use Magento\Framework\Registry;
 
@@ -42,17 +40,23 @@ abstract class Post extends Action
     }
 
     /**
-     * @return \Mirasvit\Blog\Model\Post
+     * @return \Mirasvit\Blog\Model\Post|boolean
      */
     protected function initModel()
     {
-        if ($id = $this->getRequest()->getParam('id')) {
-            $post = $this->postFactory->create()->load($id);
-            if ($post->getId() > 0) {
-                $this->registry->register('current_blog_post', $post);
-
-                return $post;
-            }
+        $id = $this->getRequest()->getParam('id');
+        if (!$id) {
+            return false;
         }
+
+        $post = $this->postFactory->create()->load($id);
+
+        if (!$post->getId()) {
+            return false;
+        }
+
+        $this->registry->register('current_blog_post', $post);
+
+        return $post;
     }
 }

--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -3,22 +3,31 @@
 namespace Mirasvit\Blog\Controller\Post;
 
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NotFoundException;
 use Mirasvit\Blog\Controller\Post;
 
 class View extends Post
 {
     /**
      * @return \Magento\Backend\Model\View\Result\Page
+     * @throws NotFoundException
      */
     public function execute()
     {
-        if ($this->initModel()) {
-            /* @var \Magento\Backend\Model\View\Result\Page $resultPage */
-            $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $post = $this->initModel();
 
-            return $resultPage;
-        } else {
-            $this->_forward('no_route');
+        if (!$post) {
+            throw new NotFoundException(__('Page not found'));
         }
+
+        /* @var \Magento\Backend\Model\View\Result\Page $resultPage */
+        $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+
+        $this->_eventManager->dispatch(
+            'blog_page_render',
+            ['post' => $post, 'controller_action' => $this]
+        );
+
+        return $resultPage;
     }
 }


### PR DESCRIPTION
This adds a `blog_page_render` event to be consistent with cms pages (`cms_page_render`).
Also refactored the `_forward` to throwing a `NotFoundException` which is the correct way to display a 404.