### PR TITLE
Fixing bug in admin panel

### DIFF
--- a/Model/ResourceModel/Post/Grid/Collection.php
+++ b/Model/ResourceModel/Post/Grid/Collection.php
@@ -8,6 +8,9 @@ use Mirasvit\Blog\Model\ResourceModel\Post\Collection as PostCollection;
 
 class Collection extends PostCollection implements SearchResultInterface
 {
+    const CAT_PROD_LINK_ALIAS = 'category_ids_table';
+    const CAT_PROD_LINK = 'mst_blog_category_post';
+
     /**
      * {@inheritdoc}
      */
@@ -70,5 +73,59 @@ class Collection extends PostCollection implements SearchResultInterface
     public function setItems(array $items = null)
     {
         return $this;
+    }
+
+    /**
+     * Overrides the basic implementation of this to add special handling for the `category_ids`
+     * column. This adds the category ids filter to be used in the Magento admin and joins that
+     * table in (grouping by the post entity_id column).
+     * 
+     * @param array|int|\Magento\Eav\Model\Entity\Attribute\AttributeInterface|string $attribute
+     * @param null $condition
+     * @param string $joinType
+     * @return $this
+     */
+    public function addAttributeToFilter($attribute, $condition = null, $joinType = 'inner')
+    {
+        $select = $this->getSelect();
+
+        if ($attribute !== "category_ids" ) {
+            return parent::addAttributeToFilter($attribute, $condition, $joinType);
+        }
+
+        if (isset($select->getPart($select::FROM)[self::CAT_PROD_LINK_ALIAS])) {
+            return $this;
+        }
+
+        $this->joinCategoryIdsTable($select);
+        $this->addConditionToSelect($select, $condition);
+
+        return $this;
+    }
+
+    /**
+     * Joins the category / post linking table into this queyr.
+     * 
+     * @param \Magento\Framework\DB\Select $select
+     */
+    private function joinCategoryIdsTable(\Magento\Framework\DB\Select $select)
+    {
+        $select->group('entity_id');
+        $select->joinInner(
+            [self::CAT_PROD_LINK_ALIAS => $this->getTable(self::CAT_PROD_LINK)],
+            'e.entity_id = ' . self::CAT_PROD_LINK_ALIAS . '.post_id',
+            'category_id'
+        );
+    }
+
+    /**
+     * Adds the condition relating to category ids.
+     * 
+     * @param \Magento\Framework\DB\Select $select
+     * @param null $condition
+     */
+    private function addConditionToSelect(\Magento\Framework\DB\Select $select, $condition = null)
+    {
+        $select->where($this->_getConditionSql(self::CAT_PROD_LINK_ALIAS . '.category_id', $condition));
     }
 }


### PR DESCRIPTION
A build that we are using this for (BTW, thank you for making this available—it's a great module) noticed that when they tried to filter blog posts by a category, they would get an error.

Digging into this, Magento was giving this error: `"category_ids" is not a valid attribute.` The reason for this is that the search result is applied to the DataProvider before `category_ids` is injected (`\Mirasvit\Blog\Ui\Component\DataProvider`, line 82). The solution isn't the cleanest, but I am not sure if there is a better way to get this done. Essentially, if the `category_ids` filter is requested, we intercept that and join in the category / post linking table.