### PR TITLE
Fix datepicker input width

### DIFF
--- a/view/adminhtml/web/css/source/module/post/_edit.less
+++ b/view/adminhtml/web/css/source/module/post/_edit.less
@@ -49,7 +49,7 @@
             input[type="text"], select, textarea {
                 width: 100%;
 
-                &.hasDatepicker {
+                &._has-datepicker {
                     width: 85%;
                 }
             }


### PR DESCRIPTION
Noticed that datepicker inputs where using the wrong class name so changed to the right one.

| Before | After |
|--------|------|
| <img width="334" alt="screen shot 2017-06-16 at 12 17 52" src="https://user-images.githubusercontent.com/661330/27224686-6a55da3c-528e-11e7-8398-67b538c26c4c.png"> | <img width="325" alt="screen shot 2017-06-16 at 12 18 03" src="https://user-images.githubusercontent.com/661330/27224690-6f8563ba-528e-11e7-9b3f-83137afc11da.png">|

