### PR TITLE
fix for magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "mirasvit/module-blog",
     "description": "Mirasvit Blog MX",
     "require": {
-        "magento/framework": "100.*|101.0.*"
+        "magento/framework": "100.*|101.0.*|102.0.*"
     },
     "suggest": {
       "mirasvit/module-blog-sample-data": "Sample Data for Blog"
     },
     "type": "magento2-module",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "license": [
       "OSL-3.0"
     ],


### PR DESCRIPTION
The Magento2.2 required framework was missing. Now module-blog can be used for magento 2.2.