### PR TITLE
Fix missing class exception

### DIFF
--- a/view/adminhtml/ui_component/blog_post_form.xml
+++ b/view/adminhtml/ui_component/blog_post_form.xml
@@ -18,8 +18,7 @@
             <item name="back" xsi:type="string">Mirasvit\Blog\Ui\Post\Form\Control\BackButton</item>
             <item name="delete" xsi:type="string">Mirasvit\Blog\Ui\Post\Form\Control\DeleteButton</item>
             <item name="save" xsi:type="string">Mirasvit\Blog\Ui\Post\Form\Control\SaveButton</item>
-            <item name="save_and_continue" xsi:type="string">Mirasvit\Blog\Ui\Post\Form\Control\SaveAndContinueButton
-            </item>
+            <item name="save_and_continue" xsi:type="string">Mirasvit\Blog\Ui\Post\Form\Control\SaveAndContinueButton</item>
         </item>
     </argument>
     <dataSource name="blog_post_form_data_source">


### PR DESCRIPTION
Magento doesn't seem to tolerate whitespace in class strings, causing `Class Mirasvit\Blog\Ui\Post\Form\Control\SaveAndContinueButton  does not exist` exception in `admin/blog/post/edit`, this fixes it.