### PR TITLE
Changing default sort order to `updated_at`

### DIFF
--- a/Model/ResourceModel/Post/Collection.php
+++ b/Model/ResourceModel/Post/Collection.php
@@ -157,7 +157,7 @@ class Collection extends AbstractCollection
     public function defaultOrder()
     {
         $this->addAttributeToSort('is_pinned', self::SORT_ORDER_DESC);
-        $this->getSelect()->order('updated_at DESC');
+        $this->getSelect()->order('created_at DESC');
 
         return $this;
     }


### PR DESCRIPTION
This method is called on the PostList regardless of other circumstances. Due to the `updated_at` sort order, the collection leans heavily towards sorting blog posts by date of update – which does not seem right.

The most obvious place where this method is called is here: [Block/Post/PostList.php#L215](https://github.com/mirasvit/module-blog/blob/master/Block/Post/PostList.php). It seems to me that it should be an `if/else` there. If that was to be done though, the `is_pinned` attribute sort would need to be moved a different method.