### PR TITLE
Few fixes

### DIFF
--- a/Block/Post/PostList.php
+++ b/Block/Post/PostList.php
@@ -5,6 +5,7 @@ namespace Mirasvit\Blog\Block\Post;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template\Context;
+use Mirasvit\Blog\Api\Data\PostInterface;
 use Mirasvit\Blog\Api\Repository\PostRepositoryInterface;
 use Mirasvit\Blog\Model\Author;
 use Mirasvit\Blog\Model\Category;

--- a/Block/Post/PostList.php
+++ b/Block/Post/PostList.php
@@ -5,7 +5,6 @@ namespace Mirasvit\Blog\Block\Post;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template\Context;
-use Mirasvit\Blog\Api\Data\PostInterface;
 use Mirasvit\Blog\Api\Repository\PostRepositoryInterface;
 use Mirasvit\Blog\Model\Author;
 use Mirasvit\Blog\Model\Category;

--- a/Block/Post/View/RelatedPosts.php
+++ b/Block/Post/View/RelatedPosts.php
@@ -47,6 +47,7 @@ class RelatedPosts extends Template
             ->addTagFilter($tags)
             ->addFieldToFilter('entity_id', ['neq' => $this->getCurrentPost()->getId()])
             ->addVisibilityFilter()
+            ->addStoreFilter($this->_storeManager->getStore()->getId())
             ->addAttributeToSelect('*');
 
         return $collection;

--- a/Model/ResourceModel/Post/Collection.php
+++ b/Model/ResourceModel/Post/Collection.php
@@ -28,6 +28,7 @@ class Collection extends AbstractCollection
     {
         $this->addAttributeToFilter(PostInterface::STATUS, PostInterface::STATUS_PUBLISHED);
         $this->addFieldToFilter(PostInterface::TYPE, PostInterface::TYPE_POST);
+        $this->addFieldToFilter(PostInterface::CREATED_AT, ['lteq' => date(DATE_ATOM)]);
 
         return $this;
     }

--- a/view/adminhtml/web/js/post/form/input-limiter.js
+++ b/view/adminhtml/web/js/post/form/input-limiter.js
@@ -37,6 +37,10 @@ define([
         
         updateNote: function (value) {
             var len = value ? value.length : 0;
+
+            if(!this.notice) { //For Magento 2.1.* (this.notice is not a function)
+                return;
+            }
             
             if (len > 0) {
                 this.notice(
@@ -52,10 +56,8 @@ define([
                     this.warn(false);
                 }
             } else {
-                // For Magento 2.1.*
-                try {
                     this.notice('');
-                } catch (e) {}
+                
             }
         }
     });


### PR DESCRIPTION
1. Issue with related posts from other stores on the post page https://3.basecamp.com/4292992/buckets/15005671/todos/2763439059
2. Display only posts with "Published at" earlier than the current date
3. Fix for Magento 2.1.* - not saving metadata in posts (this.notice is not a function) 